### PR TITLE
Add lib64 to the library search path for finding nng

### DIFF
--- a/runng-sys/build.rs
+++ b/runng-sys/build.rs
@@ -34,6 +34,11 @@ fn main() {
         "cargo:rustc-link-search=native={}",
         dst.join("lib").display()
     );
+    println!(
+        "cargo:rustc-link-search=native={}",
+        dst.join("lib64").display()
+    );
+
     // Tell rustc to use nng static library
     println!("cargo:rustc-link-lib=static=nng");
 


### PR DESCRIPTION
I ran into this on Arch linux. Cmake generates a lib64 directory, so cargo build fails. This just adds lib64 to the search path, so either lib or lib64 should build fine.