### PR TITLE
runng-sys streamlined bindgen and no_std support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,6 @@ default-members = [
     "runng",
     "runng_derive",
 ]
+
+[patch.crates-io]
+cty = { git = 'https://github.com/jeikabu/cty' }

--- a/runng-sys/Cargo.toml
+++ b/runng-sys/Cargo.toml
@@ -25,10 +25,15 @@ cmake-vs2017-win64 = [] # Visual Studio 15 2017 Win64
 nng-stats = []
 # Enable TLS (requires mbedTLS)
 nng-tls = []
+# Generate legacy API from 1.1.1-rc.4
+legacy-111-rc4 = []
+
+[dependencies]
+cty = "0.1"
 
 [build-dependencies]
 cmake = "0.1"
-bindgen = "0.40"
+bindgen = "0.47"
 
 [package.metadata.docs.rs]
 all-features = false

--- a/runng-sys/src/lib.rs
+++ b/runng-sys/src/lib.rs
@@ -4,6 +4,99 @@
 #![allow(non_snake_case)]
 // Disable clippy since this is all bindgen generated code
 #![allow(clippy::all)]
+#![no_std]
 
 // This matches bindgen::Builder output
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
+
+#[cfg(not(feature = "legacy-111-rc4"))]
+impl nng_stat_type_enum {
+    /// Converts value returned by [nng_stat_type](https://nanomsg.github.io/nng/man/v1.1.0/nng_stat_type.3) into `nng_stat_type_enum`.
+    pub fn from_i32(value: i32) -> Option<nng_stat_type_enum> {
+        use nng_stat_type_enum::*;
+        match value {
+            value if value == NNG_STAT_SCOPE as i32 => Some(NNG_STAT_SCOPE),
+            value if value == NNG_STAT_LEVEL as i32 => Some(NNG_STAT_LEVEL),
+            value if value == NNG_STAT_COUNTER as i32 => Some(NNG_STAT_COUNTER),
+            value if value == NNG_STAT_STRING as i32 => Some(NNG_STAT_STRING),
+            value if value == NNG_STAT_BOOLEAN as i32 => Some(NNG_STAT_BOOLEAN),
+            value if value == NNG_STAT_ID as i32 => Some(NNG_STAT_ID),
+            _ => None,
+        }
+    }
+}
+
+#[cfg(not(feature = "legacy-111-rc4"))]
+impl nng_unit_enum {
+    /// Converts value returned by [nng_stat_unit](https://nanomsg.github.io/nng/man/v1.1.0/nng_stat_unit.3) into `nng_unit_enum`.
+    pub fn from_i32(value: i32) -> Option<nng_unit_enum> {
+        use nng_unit_enum::*;
+        match value {
+            value if value == NNG_UNIT_NONE as i32 => Some(NNG_UNIT_NONE),
+            value if value == NNG_UNIT_BYTES as i32 => Some(NNG_UNIT_BYTES),
+            value if value == NNG_UNIT_MESSAGES as i32 => Some(NNG_UNIT_MESSAGES),
+            value if value == NNG_UNIT_MILLIS as i32 => Some(NNG_UNIT_MILLIS),
+            value if value == NNG_UNIT_EVENTS as i32 => Some(NNG_UNIT_EVENTS),
+            _ => None,
+        }
+    }
+}
+
+#[cfg(not(feature = "legacy-111-rc4"))]
+impl nng_errno_enum {
+    /// Converts value returned by NNG method into `error::Error`.
+    #[allow(clippy::cyclomatic_complexity)]
+    pub fn from_i32(value: i32) -> Option<nng_errno_enum> {
+        use nng_errno_enum::*;
+        match value {
+            value if value == NNG_EINTR as i32 => Some(NNG_EINTR),
+            value if value == NNG_ENOMEM as i32 => Some(NNG_ENOMEM),
+            value if value == NNG_EINVAL as i32 => Some(NNG_EINVAL),
+            value if value == NNG_EBUSY as i32 => Some(NNG_EBUSY),
+            value if value == NNG_ETIMEDOUT as i32 => Some(NNG_ETIMEDOUT),
+            value if value == NNG_ECONNREFUSED as i32 => Some(NNG_ECONNREFUSED),
+            value if value == NNG_ECLOSED as i32 => Some(NNG_ECLOSED),
+            value if value == NNG_EAGAIN as i32 => Some(NNG_EAGAIN),
+            value if value == NNG_ENOTSUP as i32 => Some(NNG_ENOTSUP),
+            value if value == NNG_EADDRINUSE as i32 => Some(NNG_EADDRINUSE),
+            value if value == NNG_ESTATE as i32 => Some(NNG_ESTATE),
+            value if value == NNG_ENOENT as i32 => Some(NNG_ENOENT),
+            value if value == NNG_EPROTO as i32 => Some(NNG_EPROTO),
+            value if value == NNG_EUNREACHABLE as i32 => Some(NNG_EUNREACHABLE),
+            value if value == NNG_EADDRINVAL as i32 => Some(NNG_EADDRINVAL),
+            value if value == NNG_EPERM as i32 => Some(NNG_EPERM),
+            value if value == NNG_EMSGSIZE as i32 => Some(NNG_EMSGSIZE),
+            value if value == NNG_ECONNABORTED as i32 => Some(NNG_ECONNABORTED),
+            value if value == NNG_ECONNRESET as i32 => Some(NNG_ECONNRESET),
+            value if value == NNG_ECANCELED as i32 => Some(NNG_ECANCELED),
+            value if value == NNG_ENOFILES as i32 => Some(NNG_ENOFILES),
+            value if value == NNG_ENOSPC as i32 => Some(NNG_ENOSPC),
+            value if value == NNG_EEXIST as i32 => Some(NNG_EEXIST),
+            value if value == NNG_EREADONLY as i32 => Some(NNG_EREADONLY),
+            value if value == NNG_EWRITEONLY as i32 => Some(NNG_EWRITEONLY),
+            value if value == NNG_ECRYPTO as i32 => Some(NNG_ECRYPTO),
+            value if value == NNG_EPEERAUTH as i32 => Some(NNG_EPEERAUTH),
+            value if value == NNG_ENOARG as i32 => Some(NNG_ENOARG),
+            value if value == NNG_EAMBIGUOUS as i32 => Some(NNG_EAMBIGUOUS),
+            value if value == NNG_EBADTYPE as i32 => Some(NNG_EBADTYPE),
+            value if value == NNG_EINTERNAL as i32 => Some(NNG_EINTERNAL),
+            value if value == NNG_ESYSERR as i32 => Some(NNG_ESYSERR),
+            value if value == NNG_ETRANERR as i32 => Some(NNG_ETRANERR),
+
+            _ => None,
+        }
+    }
+}
+
+#[cfg(not(feature = "legacy-111-rc4"))]
+impl nng_pipe_ev {
+    pub fn from_i32(value: i32) -> Option<nng_pipe_ev> {
+        use nng_pipe_ev::*;
+        match value {
+            value if value == NNG_PIPE_EV_ADD_PRE as i32 => Some(NNG_PIPE_EV_ADD_PRE),
+            value if value == NNG_PIPE_EV_ADD_POST as i32 => Some(NNG_PIPE_EV_ADD_POST),
+            value if value == NNG_PIPE_EV_REM_POST as i32 => Some(NNG_PIPE_EV_REM_POST),
+            _ => None,
+        }
+    }
+}

--- a/runng/benches/pushpull_bench.rs
+++ b/runng/benches/pushpull_bench.rs
@@ -1,14 +1,7 @@
 use criterion::{criterion_group, criterion_main, Criterion, ParameterizedBenchmark, Throughput};
-use futures::{future::Future, Stream};
-use runng::{asyncio::*, protocol::*, *};
-use std::{
-    sync::{
-        atomic::{AtomicUsize, Ordering},
-        Arc,
-    },
-    thread,
-    time::Duration,
-};
+use futures::future::Future;
+use runng::{asyncio::*, *};
+use std::time::Duration;
 
 fn latency(crit: &mut Criterion, url: &str) -> NngReturn {
     let url = url.to_owned();

--- a/runng/benches/reqrep_bench.rs
+++ b/runng/benches/reqrep_bench.rs
@@ -1,7 +1,7 @@
 use criterion::{criterion_group, criterion_main, Criterion, ParameterizedBenchmark, Throughput};
-use futures::{future::Future, Stream};
-use runng::{asyncio::*, protocol::*, *};
-use std::{thread, time::Duration};
+use futures::future::Future;
+use runng::{asyncio::*, *};
+use std::time::Duration;
 
 fn nng_reqrep(crit: &mut Criterion, url: &str) -> NngReturn {
     let url = url.to_owned();

--- a/runng/examples/tokio_echo.rs
+++ b/runng/examples/tokio_echo.rs
@@ -12,7 +12,7 @@ use clap::{App, Arg, ArgMatches};
 use env_logger::{Builder, Env};
 use futures::{future::lazy, Future, Stream};
 use log::info;
-use runng::{asyncio::*, protocol::*, *};
+use runng::{asyncio::*, *};
 
 fn main() -> NngReturn {
     Builder::from_env(Env::default().default_filter_or("debug"))

--- a/runng/src/asyncio/pull.rs
+++ b/runng/src/asyncio/pull.rs
@@ -84,7 +84,8 @@ unsafe extern "C" fn read_callback(arg: AioCallbackArg) {
             match res {
                 // nng_aio_close() calls nng_aio_stop which nng_aio_abort(NNG_ECANCELED) and waits.
                 // If we call start_receive() it will fail with ECANCELED and we infinite loop...
-                NngFail::Err(NngError::ECLOSED) | NngFail::Err(NngError::ECANCELED) => {
+                NngFail::Err(nng_errno_enum::NNG_ECLOSED)
+                | NngFail::Err(nng_errno_enum::NNG_ECANCELED) => {
                     debug!("read_callback {:?}", res);
                 }
                 _ => {

--- a/runng/src/asyncio/pull_stream.rs
+++ b/runng/src/asyncio/pull_stream.rs
@@ -98,7 +98,8 @@ unsafe extern "C" fn pull_callback(arg: AioCallbackArg) {
                     match res {
                         // nng_aio_close() calls nng_aio_stop which nng_aio_abort(NNG_ECANCELED) and waits.
                         // If we call start_receive() it will fail with ECANCELED and we infinite loop...
-                        NngFail::Err(NngError::ECLOSED) | NngFail::Err(NngError::ECANCELED) => {
+                        NngFail::Err(nng_errno_enum::NNG_ECLOSED)
+                        | NngFail::Err(nng_errno_enum::NNG_ECANCELED) => {
                             debug!("pull_callback {:?}", res);
                         }
                         _ => {

--- a/runng/src/asyncio/reply.rs
+++ b/runng/src/asyncio/reply.rs
@@ -130,7 +130,8 @@ unsafe extern "C" fn reply_callback(arg: AioCallbackArg) {
             match res {
                 Err(res) => {
                     match res {
-                        NngFail::Err(NngError::ECLOSED) | NngFail::Err(NngError::ECANCELED) => {
+                        NngFail::Err(nng_errno_enum::NNG_ECLOSED)
+                        | NngFail::Err(nng_errno_enum::NNG_ECANCELED) => {
                             debug!("reply_callback {:?}", res);
                         }
                         _ => {

--- a/runng/src/asyncio/reply_stream.rs
+++ b/runng/src/asyncio/reply_stream.rs
@@ -125,7 +125,8 @@ unsafe extern "C" fn reply_callback(arg: AioCallbackArg) {
             match res {
                 Err(res) => {
                     match res {
-                        NngFail::Err(NngError::ECLOSED) | NngFail::Err(NngError::ECANCELED) => {
+                        NngFail::Err(nng_errno_enum::NNG_ECLOSED)
+                        | NngFail::Err(nng_errno_enum::NNG_ECANCELED) => {
                             debug!("reply_callback {:?}", res);
                         }
                         _ => {

--- a/runng/src/pipe.rs
+++ b/runng/src/pipe.rs
@@ -7,31 +7,6 @@ use crate::{dialer::UnsafeDialer, listener::UnsafeListener, msg::NngMsg};
 use runng_derive::NngGetOpts;
 use runng_sys::*;
 
-/// Pipe events.  See [nng_pipe_notify](https://nanomsg.github.io/nng/man/v1.1.0/nng_pipe_notify.3).
-#[derive(Clone, Copy, Debug)]
-#[repr(i32)]
-pub enum PipeEvent {
-    /// This event occurs after a connection and negotiation has completed, but before the pipe is added to the socket.
-    AddPre = nng_pipe_ev_NNG_PIPE_EV_ADD_PRE as i32,
-    /// This event occurs after the pipe is fully added to the socket.
-    /// Prior to this time, it is not possible to communicate over the pipe with the socket.
-    AddPost = nng_pipe_ev_NNG_PIPE_EV_ADD_POST as i32,
-    /// This event occurs after the pipe has been removed from the socket.
-    /// The underlying transport may be closed at this point, and it is not possible communicate using this pipe.
-    RemPost = nng_pipe_ev_NNG_PIPE_EV_REM_POST as i32,
-}
-
-impl PipeEvent {
-    pub fn from_i32(value: i32) -> Option<PipeEvent> {
-        match value {
-            value if value == PipeEvent::AddPre as i32 => Some(PipeEvent::AddPre),
-            value if value == PipeEvent::AddPost as i32 => Some(PipeEvent::AddPost),
-            value if value == PipeEvent::RemPost as i32 => Some(PipeEvent::RemPost),
-            _ => None,
-        }
-    }
-}
-
 pub type PipeNotifyCallback =
     unsafe extern "C" fn(pipe: nng_pipe, event: i32, arg1: PipeNotifyCallbackArg);
 pub type PipeNotifyCallbackArg = *mut ::std::os::raw::c_void;

--- a/runng/src/result.rs
+++ b/runng/src/result.rs
@@ -4,92 +4,9 @@ use futures::sync::oneshot;
 use runng_sys::*;
 use std::{error, fmt, io};
 
-/// Error values returned by NNG functions.
-#[derive(Clone, Copy, Debug, PartialEq)]
-#[repr(i32)]
-pub enum NngError {
-    EINTR = nng_errno_enum_NNG_EINTR as i32,
-    ENOMEM = nng_errno_enum_NNG_ENOMEM as i32,
-    EINVAL = nng_errno_enum_NNG_EINVAL as i32,
-    EBUSY = nng_errno_enum_NNG_EBUSY as i32,
-    ETIMEDOUT = nng_errno_enum_NNG_ETIMEDOUT as i32,
-    ECONNREFUSED = nng_errno_enum_NNG_ECONNREFUSED as i32,
-    ECLOSED = nng_errno_enum_NNG_ECLOSED as i32,
-    EAGAIN = nng_errno_enum_NNG_EAGAIN as i32,
-    ENOTSUP = nng_errno_enum_NNG_ENOTSUP as i32,
-    EADDRINUSE = nng_errno_enum_NNG_EADDRINUSE as i32,
-    ESTATE = nng_errno_enum_NNG_ESTATE as i32,
-    ENOENT = nng_errno_enum_NNG_ENOENT as i32,
-    EPROTO = nng_errno_enum_NNG_EPROTO as i32,
-    EUNREACHABLE = nng_errno_enum_NNG_EUNREACHABLE as i32,
-    EADDRINVAL = nng_errno_enum_NNG_EADDRINVAL as i32,
-    EPERM = nng_errno_enum_NNG_EPERM as i32,
-    EMSGSIZE = nng_errno_enum_NNG_EMSGSIZE as i32,
-    ECONNABORTED = nng_errno_enum_NNG_ECONNABORTED as i32,
-    ECONNRESET = nng_errno_enum_NNG_ECONNRESET as i32,
-    ECANCELED = nng_errno_enum_NNG_ECANCELED as i32,
-    ENOFILES = nng_errno_enum_NNG_ENOFILES as i32,
-    ENOSPC = nng_errno_enum_NNG_ENOSPC as i32,
-    EEXIST = nng_errno_enum_NNG_EEXIST as i32,
-    EREADONLY = nng_errno_enum_NNG_EREADONLY as i32,
-    EWRITEONLY = nng_errno_enum_NNG_EWRITEONLY as i32,
-    ECRYPTO = nng_errno_enum_NNG_ECRYPTO as i32,
-    EPEERAUTH = nng_errno_enum_NNG_EPEERAUTH as i32,
-    ENOARG = nng_errno_enum_NNG_ENOARG as i32,
-    EAMBIGUOUS = nng_errno_enum_NNG_EAMBIGUOUS as i32,
-    EBADTYPE = nng_errno_enum_NNG_EBADTYPE as i32,
-    EINTERNAL = nng_errno_enum_NNG_EINTERNAL as i32,
-    ESYSERR = nng_errno_enum_NNG_ESYSERR as i32,
-    ETRANERR = nng_errno_enum_NNG_ETRANERR as i32,
-}
-
-impl NngError {
-    /// Converts value returned by NNG method into `error::Error`.
-    #[allow(clippy::cyclomatic_complexity)]
-    pub fn from_i32(value: i32) -> Option<NngError> {
-        match value {
-            value if value == NngError::EINTR as i32 => Some(NngError::EINTR),
-            value if value == NngError::ENOMEM as i32 => Some(NngError::ENOMEM),
-            value if value == NngError::EINVAL as i32 => Some(NngError::EINVAL),
-            value if value == NngError::EBUSY as i32 => Some(NngError::EBUSY),
-            value if value == NngError::ETIMEDOUT as i32 => Some(NngError::ETIMEDOUT),
-            value if value == NngError::ECONNREFUSED as i32 => Some(NngError::ECONNREFUSED),
-            value if value == NngError::ECLOSED as i32 => Some(NngError::ECLOSED),
-            value if value == NngError::EAGAIN as i32 => Some(NngError::EAGAIN),
-            value if value == NngError::ENOTSUP as i32 => Some(NngError::ENOTSUP),
-            value if value == NngError::EADDRINUSE as i32 => Some(NngError::EADDRINUSE),
-            value if value == NngError::ESTATE as i32 => Some(NngError::ESTATE),
-            value if value == NngError::ENOENT as i32 => Some(NngError::ENOENT),
-            value if value == NngError::EPROTO as i32 => Some(NngError::EPROTO),
-            value if value == NngError::EUNREACHABLE as i32 => Some(NngError::EUNREACHABLE),
-            value if value == NngError::EADDRINVAL as i32 => Some(NngError::EADDRINVAL),
-            value if value == NngError::EPERM as i32 => Some(NngError::EPERM),
-            value if value == NngError::EMSGSIZE as i32 => Some(NngError::EMSGSIZE),
-            value if value == NngError::ECONNABORTED as i32 => Some(NngError::ECONNABORTED),
-            value if value == NngError::ECONNRESET as i32 => Some(NngError::ECONNRESET),
-            value if value == NngError::ECANCELED as i32 => Some(NngError::ECANCELED),
-            value if value == NngError::ENOFILES as i32 => Some(NngError::ENOFILES),
-            value if value == NngError::ENOSPC as i32 => Some(NngError::ENOSPC),
-            value if value == NngError::EEXIST as i32 => Some(NngError::EEXIST),
-            value if value == NngError::EREADONLY as i32 => Some(NngError::EREADONLY),
-            value if value == NngError::EWRITEONLY as i32 => Some(NngError::EWRITEONLY),
-            value if value == NngError::ECRYPTO as i32 => Some(NngError::ECRYPTO),
-            value if value == NngError::EPEERAUTH as i32 => Some(NngError::EPEERAUTH),
-            value if value == NngError::ENOARG as i32 => Some(NngError::ENOARG),
-            value if value == NngError::EAMBIGUOUS as i32 => Some(NngError::EAMBIGUOUS),
-            value if value == NngError::EBADTYPE as i32 => Some(NngError::EBADTYPE),
-            value if value == NngError::EINTERNAL as i32 => Some(NngError::EINTERNAL),
-            value if value == NngError::ESYSERR as i32 => Some(NngError::ESYSERR),
-            value if value == NngError::ETRANERR as i32 => Some(NngError::ETRANERR),
-
-            _ => None,
-        }
-    }
-}
-
 #[derive(Debug)]
 pub enum NngFail {
-    Err(NngError),
+    Err(nng_errno_enum),
     Unknown(i32),
     IoError(io::Error),
     NulError(std::ffi::NulError),
@@ -103,7 +20,7 @@ impl NngFail {
     pub fn from_i32(value: i32) -> NngReturn {
         if value == 0 {
             Ok(())
-        } else if let Some(error) = NngError::from_i32(value) {
+        } else if let Some(error) = nng_errno_enum::from_i32(value) {
             Err(NngFail::Err(error))
         } else {
             Err(NngFail::Unknown(value))
@@ -120,14 +37,6 @@ impl NngFail {
             Ok(()) => Ok(result()),
             Err(error) => Err(error),
         }
-    }
-}
-
-impl error::Error for NngError {}
-
-impl fmt::Display for NngError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self)
     }
 }
 

--- a/runng/src/socket.rs
+++ b/runng/src/socket.rs
@@ -30,7 +30,7 @@ impl NngSocket {
     #[cfg(feature = "pipes")]
     pub fn notify(
         &self,
-        event: pipe::PipeEvent,
+        event: nng_pipe_ev,
         callback: pipe::PipeNotifyCallback,
         argument: pipe::PipeNotifyCallbackArg,
     ) -> NngReturn {
@@ -247,7 +247,7 @@ impl Drop for InnerSocket {
             match res {
                 Ok(()) => {}
                 // Can't panic here.  Thrift's TIoChannel::split() clones the socket handle so we may get ECLOSED
-                Err(NngFail::Err(NngError::ECLOSED)) => {}
+                Err(NngFail::Err(nng_errno_enum::NNG_ECLOSED)) => {}
                 Err(res) => {
                     debug!("nng_close {:?}", res);
                     panic!("nng_close {:?}", res);

--- a/runng/src/stats.rs
+++ b/runng/src/stats.rs
@@ -46,58 +46,6 @@ use crate::*;
 use runng_sys::*;
 use std::marker;
 
-/// Type of statistic.  See `NngStatChild::stat_type`.
-#[derive(Clone, Copy, Debug)]
-#[repr(i32)]
-pub enum NngStatType {
-    Scope = nng_stat_type_enum_NNG_STAT_SCOPE as i32,
-    Level = nng_stat_type_enum_NNG_STAT_LEVEL as i32,
-    Counter = nng_stat_type_enum_NNG_STAT_COUNTER as i32,
-    String = nng_stat_type_enum_NNG_STAT_STRING as i32,
-    Boolean = nng_stat_type_enum_NNG_STAT_BOOLEAN as i32,
-    Id = nng_stat_type_enum_NNG_STAT_ID as i32,
-}
-
-impl NngStatType {
-    /// Converts value returned by [nng_stat_type](https://nanomsg.github.io/nng/man/v1.1.0/nng_stat_type.3) into `NngStatType`.
-    pub fn from_i32(value: i32) -> Option<NngStatType> {
-        match value {
-            value if value == NngStatType::Scope as i32 => Some(NngStatType::Scope),
-            value if value == NngStatType::Level as i32 => Some(NngStatType::Level),
-            value if value == NngStatType::Counter as i32 => Some(NngStatType::Counter),
-            value if value == NngStatType::String as i32 => Some(NngStatType::String),
-            value if value == NngStatType::Boolean as i32 => Some(NngStatType::Boolean),
-            value if value == NngStatType::Id as i32 => Some(NngStatType::Id),
-            _ => None,
-        }
-    }
-}
-
-/// Unit of quantity measured by statistic.  See `NngStatChild::unit()`.
-#[derive(Clone, Copy, Debug)]
-#[repr(i32)]
-pub enum NngStatUnit {
-    None = nng_unit_enum_NNG_UNIT_NONE as i32,
-    Bytes = nng_unit_enum_NNG_UNIT_BYTES as i32,
-    Messages = nng_unit_enum_NNG_UNIT_MESSAGES as i32,
-    Millis = nng_unit_enum_NNG_UNIT_MILLIS as i32,
-    Events = nng_unit_enum_NNG_UNIT_EVENTS as i32,
-}
-
-impl NngStatUnit {
-    /// Converts value returned by [nng_stat_unit](https://nanomsg.github.io/nng/man/v1.1.0/nng_stat_unit.3) into `NngStatUnit`.
-    pub fn from_i32(value: i32) -> Option<NngStatUnit> {
-        match value {
-            value if value == NngStatUnit::None as i32 => Some(NngStatUnit::None),
-            value if value == NngStatUnit::Bytes as i32 => Some(NngStatUnit::Bytes),
-            value if value == NngStatUnit::Messages as i32 => Some(NngStatUnit::Messages),
-            value if value == NngStatUnit::Millis as i32 => Some(NngStatUnit::Millis),
-            value if value == NngStatUnit::Events as i32 => Some(NngStatUnit::Events),
-            _ => None,
-        }
-    }
-}
-
 pub trait NngStat {
     /// Obtain underlying [`nng_stat`](https://nanomsg.github.io/nng/man/v1.1.0/nng_stat.5).
     unsafe fn nng_stat(&self) -> *mut nng_stat;
@@ -185,10 +133,10 @@ impl<'root> NngStatChild<'root> {
     }
 
     /// See [nng_stat_type](https://nanomsg.github.io/nng/man/v1.1.0/nng_stat_type.3).
-    pub fn stat_type(&self) -> Option<NngStatType> {
+    pub fn stat_type(&self) -> Option<nng_stat_type_enum> {
         unsafe {
             let val = nng_stat_type(self.nng_stat());
-            NngStatType::from_i32(val)
+            nng_stat_type_enum::from_i32(val)
         }
     }
 
@@ -216,10 +164,10 @@ impl<'root> NngStatChild<'root> {
     }
 
     /// See [nng_stat_unit](https://nanomsg.github.io/nng/man/v1.1.0/nng_stat_unit.3).
-    pub fn unit(&self) -> Option<NngStatUnit> {
+    pub fn unit(&self) -> Option<nng_unit_enum> {
         unsafe {
             let val = nng_stat_unit(self.nng_stat());
-            NngStatUnit::from_i32(val)
+            nng_unit_enum::from_i32(val)
         }
     }
 

--- a/runng/tests/tests/pipe_tests.rs
+++ b/runng/tests/tests/pipe_tests.rs
@@ -3,7 +3,7 @@
 use crate::common::{get_url, sleep_fast};
 use runng::pipe::*;
 use runng::*;
-use runng_sys::nng_pipe;
+use runng_sys::{nng_pipe, nng_pipe_ev, nng_pipe_ev::*};
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 static NUM_ADDPRE: AtomicUsize = AtomicUsize::new(0);
@@ -12,10 +12,10 @@ static NUM_REMPOST: AtomicUsize = AtomicUsize::new(0);
 static NUM_BAD: AtomicUsize = AtomicUsize::new(0);
 
 extern "C" fn notify_callback(_pipe: nng_pipe, event: i32, _arg: PipeNotifyCallbackArg) {
-    match PipeEvent::from_i32(event) {
-        Some(PipeEvent::AddPre) => NUM_ADDPRE.fetch_add(1, Ordering::Relaxed),
-        Some(PipeEvent::AddPost) => NUM_ADDPOST.fetch_add(1, Ordering::Relaxed),
-        Some(PipeEvent::RemPost) => NUM_REMPOST.fetch_add(1, Ordering::Relaxed),
+    match nng_pipe_ev::from_i32(event) {
+        Some(NNG_PIPE_EV_ADD_PRE) => NUM_ADDPRE.fetch_add(1, Ordering::Relaxed),
+        Some(NNG_PIPE_EV_ADD_POST) => NUM_ADDPOST.fetch_add(1, Ordering::Relaxed),
+        Some(NNG_PIPE_EV_REM_POST) => NUM_REMPOST.fetch_add(1, Ordering::Relaxed),
         _ => NUM_BAD.fetch_add(1, Ordering::Relaxed),
     };
 }
@@ -26,13 +26,17 @@ fn notify() -> NngReturn {
 
     let factory = Latest::default();
     let rep = factory.replier_open()?.listen(&url)?;
-    [PipeEvent::AddPre, PipeEvent::AddPost, PipeEvent::RemPost]
-        .iter()
-        .for_each(|event| {
-            rep.socket()
-                .notify(*event, notify_callback, std::ptr::null_mut())
-                .unwrap()
-        });
+    [
+        NNG_PIPE_EV_ADD_PRE,
+        NNG_PIPE_EV_ADD_POST,
+        NNG_PIPE_EV_REM_POST,
+    ]
+    .iter()
+    .for_each(|event| {
+        rep.socket()
+            .notify(*event, notify_callback, std::ptr::null_mut())
+            .unwrap()
+    });
     {
         let _ = factory.requester_open()?.dial(&url)?;
         // Give all notifications a chance to be delivered (especially Linux Travis CI)

--- a/runng/tests/tests/reqrep_tests.rs
+++ b/runng/tests/tests/reqrep_tests.rs
@@ -1,6 +1,6 @@
 use crate::common::{create_stop_message, get_url, not_stop_message};
 use futures::{future::Future, Stream};
-use log::{debug, info};
+use log::info;
 use runng::{asyncio::*, *};
 use std::{
     sync::{


### PR DESCRIPTION
- Using patched cty to avoid conflict between cty::c_void and core::ffi::c_void
- Whitelist NNG API rather than blacklisting stuff we don't want
- Bindgen now generates C enum as rust enum
- Move impl enum to runng-sys/lib.rs so in same crate as types
- Old runng-sys API available via "legacy-111-r4" feature