### PR TITLE
Use Default trait, nng errno values wrapped by NngErrno, and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Runng
+# RuNNG
 
 Rust [NNG (Nanomsg-Next-Generation)](https://github.com/nanomsg/nng):
 
@@ -10,9 +10,9 @@ Rust [NNG (Nanomsg-Next-Generation)](https://github.com/nanomsg/nng):
 [![docs.rs](https://docs.rs/runng/badge.svg)](https://docs.rs/crate/runng/)
 
 
-||||
+|Repository|Crate|Details|
 |-|-|-
-| __runng-sys__ | [![runng-sys crate](https://img.shields.io/crates/v/runng-sys.svg)](https://crates.io/crates/runng-sys) | bindings to native NNG library
+| [__runng-sys__](https://github.com/jeikabu/nng-rust) | [![runng-sys crate](https://img.shields.io/crates/v/runng-sys.svg)](https://crates.io/crates/runng-sys) | bindings to native NNG library
 | __runng__ | [![runng crate](https://img.shields.io/crates/v/runng.svg)](https://crates.io/crates/runng) | high-level wrapper for NNG
 | [__runng_thrift__](https://github.com/jeikabu/runng_thrift) | [![runng-thrift crate](https://img.shields.io/crates/v/runng-thrift.svg)](https://crates.io/crates/runng-thrift) | NNG as [Apache Thrift](https://github.com/apache/thrift) transport
 | [__runng_examples__](https://github.com/jeikabu/runng_examples) | | Additional runng examples
@@ -21,9 +21,7 @@ Rust [NNG (Nanomsg-Next-Generation)](https://github.com/nanomsg/nng):
 
 In `Cargo.toml`:
 ```toml
-runng = "0.1"
-# OR
-runng-sys = "1.1.1-rc"
+runng = "0.2"
 ```
 
 Requirements:
@@ -37,5 +35,3 @@ Requirements:
 1. Update submodules: `git submodule update --init --recursive`
 1. Install requirements
 1. `cargo build`
-
-To build optional packages: `cargo build --all`

--- a/runng/Cargo.toml
+++ b/runng/Cargo.toml
@@ -28,7 +28,7 @@ futures = "0.1"
 log = "0.4"
 rand = "0.6"
 runng_derive = { version = "0.1", path = "../runng_derive" }
-runng-sys = { version = "1.1.1-rc", path = "../runng_sys" }
+runng-sys = { version = "1.1.1-rc", path = "../runng_sys", package = "nng-sys", features = ["build-bindgen"] }
 
 [dev-dependencies]
 env_logger = "0.6"

--- a/runng/src/aio.rs
+++ b/runng/src/aio.rs
@@ -42,7 +42,7 @@ impl NngAio {
             //https://doc.rust-lang.org/stable/book/first-edition/ffi.html#callbacks-from-c-code-to-rust-functions
             let res = nng_aio_alloc(&mut aio, Some(callback), arg);
             self.aio = aio;
-            Error::from_i32(res)
+            nng_int_to_result(res)
         }
     }
 

--- a/runng/src/asyncio/pull.rs
+++ b/runng/src/asyncio/pull.rs
@@ -79,15 +79,14 @@ unsafe extern "C" fn read_callback(arg: AioCallbackArg) {
     let ctx = &mut *(arg as *mut PullAioArg);
     let aio = ctx.aio.nng_aio();
     let aio_res = nng_aio_result(aio);
-    let res = Error::from_i32(aio_res);
+    let res = nng_int_to_result(aio_res);
     trace!("read_callback::{:?}", res);
     match res {
         Err(res) => {
             match res {
                 // nng_aio_close() calls nng_aio_stop which nng_aio_abort(NNG_ECANCELED) and waits.
                 // If we call start_receive() it will fail with ECANCELED and we infinite loop...
-                Error::Errno(nng_errno_enum::NNG_ECLOSED)
-                | Error::Errno(nng_errno_enum::NNG_ECANCELED) => {
+                Error::Errno(NngErrno::ECLOSED) | Error::Errno(NngErrno::ECANCELED) => {
                     debug!("read_callback {:?}", res);
                 }
                 _ => {

--- a/runng/src/asyncio/pull_stream.rs
+++ b/runng/src/asyncio/pull_stream.rs
@@ -91,14 +91,13 @@ unsafe extern "C" fn pull_callback(arg: AioCallbackArg) {
         PullState::Receiving => {
             let aio = ctx.aio.nng_aio();
             let aio_res = nng_aio_result(aio);
-            let res = Error::from_i32(aio_res);
+            let res = nng_int_to_result(aio_res);
             match res {
                 Err(res) => {
                     match res {
                         // nng_aio_close() calls nng_aio_stop which nng_aio_abort(NNG_ECANCELED) and waits.
                         // If we call start_receive() it will fail with ECANCELED and we infinite loop...
-                        Error::Errno(nng_errno_enum::NNG_ECLOSED)
-                        | Error::Errno(nng_errno_enum::NNG_ECANCELED) => {
+                        Error::Errno(NngErrno::ECLOSED) | Error::Errno(NngErrno::ECANCELED) => {
                             debug!("pull_callback {:?}", res);
                         }
                         _ => {

--- a/runng/src/asyncio/push.rs
+++ b/runng/src/asyncio/push.rs
@@ -100,7 +100,7 @@ unsafe extern "C" fn publish_callback(arg: AioCallbackArg) {
         PushState::Ready => panic!(),
         PushState::Sending => {
             let nng_aio = ctx.aio.nng_aio();
-            let res = Error::from_i32(nng_aio_result(nng_aio));
+            let res = nng_int_to_result(nng_aio_result(nng_aio));
             if let Err(ref err) = res {
                 debug!("Push failed: {:?}", err);
                 // Nng requires that we retrieve the message and free it

--- a/runng/src/asyncio/reply.rs
+++ b/runng/src/asyncio/reply.rs
@@ -128,12 +128,11 @@ unsafe extern "C" fn reply_callback(arg: AioCallbackArg) {
     match ctx.state {
         ReplyState::Idle => panic!(),
         ReplyState::Receiving => {
-            let res = Error::from_i32(nng_aio_result(aio_nng));
+            let res = nng_int_to_result(nng_aio_result(aio_nng));
             match res {
                 Err(res) => {
                     match res {
-                        Error::Errno(nng_errno_enum::NNG_ECLOSED)
-                        | Error::Errno(nng_errno_enum::NNG_ECANCELED) => {
+                        Error::Errno(NngErrno::ECLOSED) | Error::Errno(NngErrno::ECANCELED) => {
                             debug!("reply_callback {:?}", res);
                         }
                         _ => {
@@ -154,7 +153,7 @@ unsafe extern "C" fn reply_callback(arg: AioCallbackArg) {
         }
         ReplyState::Wait => panic!(),
         ReplyState::Sending => {
-            let res = Error::from_i32(nng_aio_result(aio_nng));
+            let res = nng_int_to_result(nng_aio_result(aio_nng));
             if res.is_err() {
                 // Nng requires we resume ownership of the message
                 let _ = NngMsg::new_msg(nng_aio_get_msg(aio_nng));

--- a/runng/src/asyncio/reply_stream.rs
+++ b/runng/src/asyncio/reply_stream.rs
@@ -123,12 +123,11 @@ unsafe extern "C" fn reply_callback(arg: AioCallbackArg) {
     trace!("reply_callback::{:?}", ctx.state);
     match ctx.state {
         ReplyState::Receiving => {
-            let res = Error::from_i32(nng_aio_result(aio_nng));
+            let res = nng_int_to_result(nng_aio_result(aio_nng));
             match res {
                 Err(res) => {
                     match res {
-                        Error::Errno(nng_errno_enum::NNG_ECLOSED)
-                        | Error::Errno(nng_errno_enum::NNG_ECANCELED) => {
+                        Error::Errno(NngErrno::ECLOSED) | Error::Errno(NngErrno::ECANCELED) => {
                             debug!("reply_callback {:?}", res);
                         }
                         _ => {
@@ -149,7 +148,7 @@ unsafe extern "C" fn reply_callback(arg: AioCallbackArg) {
         }
         ReplyState::Wait => panic!(),
         ReplyState::Sending => {
-            let res = Error::from_i32(nng_aio_result(aio_nng));
+            let res = nng_int_to_result(nng_aio_result(aio_nng));
             if res.is_err() {
                 // Nng requires we resume ownership of the message
                 let _ = NngMsg::new_msg(nng_aio_get_msg(aio_nng));

--- a/runng/src/asyncio/request.rs
+++ b/runng/src/asyncio/request.rs
@@ -98,7 +98,7 @@ unsafe extern "C" fn request_callback(arg: AioCallbackArg) {
     match ctx.state {
         RequestState::Ready => panic!(),
         RequestState::Sending => {
-            let res = Error::from_i32(nng_aio_result(aionng));
+            let res = nng_int_to_result(nng_aio_result(aionng));
             match res {
                 Err(res) => {
                     // Nng requries we resume ownership of the message
@@ -116,7 +116,7 @@ unsafe extern "C" fn request_callback(arg: AioCallbackArg) {
         }
         RequestState::Receiving => {
             let sender = ctx.sender.take().unwrap();
-            let res = Error::from_i32(nng_aio_result(aionng));
+            let res = nng_int_to_result(nng_aio_result(aionng));
             match res {
                 Err(res) => {
                     ctx.state = RequestState::Ready;

--- a/runng/src/dialer.rs
+++ b/runng/src/dialer.rs
@@ -17,7 +17,7 @@ impl NngDialer {
     /// See [nng_dialer_create](https://nanomsg.github.io/nng/man/v1.1.0/nng_dialer_create.3).
     pub(crate) fn create(socket: NngSocket, url: &str) -> Result<Self> {
         unsafe {
-            let mut dialer = nng_dialer { id: 0 };
+            let mut dialer = nng_dialer::default();
             let (_cstring, url) = to_cstr(url)?;
             Error::zero_map(
                 nng_dialer_create(&mut dialer, socket.nng_socket(), url),
@@ -29,7 +29,7 @@ impl NngDialer {
     // TODO: Use different type for started vs non-started dialer?  According to nng docs options can generally only
     // be set before the dialer is started.
     pub fn start(&self) -> Result<()> {
-        unsafe { Error::from_i32(nng_dialer_start(self.dialer, 0)) }
+        unsafe { nng_int_to_result(nng_dialer_start(self.dialer, 0)) }
     }
 }
 

--- a/runng/src/listener.rs
+++ b/runng/src/listener.rs
@@ -17,7 +17,7 @@ impl NngListener {
     /// See [nng_listener_create](https://nanomsg.github.io/nng/man/v1.1.0/nng_listener_create.3).
     pub(crate) fn create(socket: NngSocket, url: &str) -> Result<Self> {
         unsafe {
-            let mut listener = nng_listener { id: 0 };
+            let mut listener = nng_listener::default();
             let (_cstring, url) = to_cstr(url)?;
             let res = nng_listener_create(&mut listener, socket.nng_socket(), url);
             Error::zero_map(res, || NngListener { listener, socket })
@@ -28,7 +28,7 @@ impl NngListener {
     pub fn start(&self) -> Result<()> {
         // TODO: Use different type for started vs non-started dialer?  According to nng docs options can generally only
         // be set before the dialer is started.
-        unsafe { Error::from_i32(nng_listener_start(self.listener, 0)) }
+        unsafe { nng_int_to_result(nng_listener_start(self.listener, 0)) }
     }
 }
 

--- a/runng/src/msg/msg.rs
+++ b/runng/src/msg/msg.rs
@@ -82,7 +82,7 @@ impl NngMsg {
     }
 
     pub fn append_ptr(&mut self, data: *const u8, size: usize) -> Result<()> {
-        unsafe { Error::from_i32(nng_msg_append(self.msg(), data as *const c_void, size)) }
+        unsafe { nng_int_to_result(nng_msg_append(self.msg(), data as *const c_void, size)) }
     }
 
     pub fn insert_slice(&mut self, data: &[u8]) -> Result<()> {
@@ -90,15 +90,15 @@ impl NngMsg {
     }
 
     pub fn insert_ptr(&mut self, data: *const u8, size: usize) -> Result<()> {
-        unsafe { Error::from_i32(nng_msg_insert(self.msg(), data as *const c_void, size)) }
+        unsafe { nng_int_to_result(nng_msg_insert(self.msg(), data as *const c_void, size)) }
     }
 
     pub fn trim(&mut self, size: usize) -> Result<()> {
-        unsafe { Error::from_i32(nng_msg_trim(self.msg(), size)) }
+        unsafe { nng_int_to_result(nng_msg_trim(self.msg(), size)) }
     }
 
     pub fn chop(&mut self, size: usize) -> Result<()> {
-        unsafe { Error::from_i32(nng_msg_chop(self.msg(), size)) }
+        unsafe { nng_int_to_result(nng_msg_chop(self.msg(), size)) }
     }
 
     pub fn header_append_slice(&mut self, data: &[u8]) -> Result<()> {
@@ -107,7 +107,7 @@ impl NngMsg {
 
     pub fn header_append_ptr(&mut self, data: *const u8, size: usize) -> Result<()> {
         unsafe {
-            Error::from_i32(nng_msg_header_append(
+            nng_int_to_result(nng_msg_header_append(
                 self.msg(),
                 data as *const c_void,
                 size,
@@ -121,7 +121,7 @@ impl NngMsg {
 
     pub fn header_insert_ptr(&mut self, data: *const u8, size: usize) -> Result<()> {
         unsafe {
-            Error::from_i32(nng_msg_header_insert(
+            nng_int_to_result(nng_msg_header_insert(
                 self.msg(),
                 data as *const c_void,
                 size,
@@ -130,11 +130,11 @@ impl NngMsg {
     }
 
     pub fn header_trim(&mut self, size: usize) -> Result<()> {
-        unsafe { Error::from_i32(nng_msg_header_trim(self.msg(), size)) }
+        unsafe { nng_int_to_result(nng_msg_header_trim(self.msg(), size)) }
     }
 
     pub fn header_chop(&mut self, size: usize) -> Result<()> {
-        unsafe { Error::from_i32(nng_msg_header_chop(self.msg(), size)) }
+        unsafe { nng_int_to_result(nng_msg_header_chop(self.msg(), size)) }
     }
 
     pub fn dup(&self) -> Result<NngMsg> {

--- a/runng/src/pipe.rs
+++ b/runng/src/pipe.rs
@@ -24,7 +24,8 @@ impl NngPipe {
     pub(crate) fn create(message: &NngMsg) -> Option<Self> {
         unsafe {
             let pipe = nng_msg_get_pipe(message.msg());
-            if (pipe.id as i32) < 0 {
+            let id = nng_pipe_id(pipe);
+            if id <= 0 {
                 None
             } else {
                 Some(NngPipe { pipe })
@@ -75,6 +76,6 @@ impl NngPipe {
     /// Closes the pipe.  See [nng_pipe_close](https://nanomsg.github.io/nng/man/v1.1.0/nng_pipe_close.3).
     /// This will cause associated aio/ctx functions that were using the pipe to fail.
     pub unsafe fn close(self) -> Result<()> {
-        Error::from_i32(nng_pipe_close(self.pipe))
+        nng_int_to_result(nng_pipe_close(self.pipe))
     }
 }

--- a/runng/src/protocol/mod.rs
+++ b/runng/src/protocol/mod.rs
@@ -33,7 +33,7 @@ where
     O: Fn(&mut nng_socket) -> i32,
     S: Fn(NngSocket) -> T,
 {
-    let mut socket = nng_socket { id: 0 };
+    let mut socket = nng_socket::default();
     let res = open_func(&mut socket);
     Error::zero_map(res, || {
         let socket = NngSocket::new(socket);
@@ -47,6 +47,6 @@ pub(crate) fn subscribe(socket: nng_socket, topic: &[u8]) -> Result<()> {
         let topic_ptr = topic.as_ptr() as *const ::std::os::raw::c_void;
         let topic_size = std::mem::size_of_val(topic);
         let res = nng_setopt(socket, opt, topic_ptr, topic_size);
-        Error::from_i32(res)
+        nng_int_to_result(res)
     }
 }

--- a/runng/src/result.rs
+++ b/runng/src/result.rs
@@ -2,45 +2,137 @@
 
 use futures::sync::oneshot;
 use runng_sys::*;
-use std::{error, fmt, io, result};
+use std::{error, fmt, result};
 
 pub type Result<T> = result::Result<T, Error>;
 
-#[derive(Debug)]
+/// Converts integers returned by NNG methods into `Result`.
+/// 0 is Ok() and anything else is Err()
+pub fn nng_int_to_result(value: i32) -> Result<()> {
+    if value == 0 {
+        Ok(())
+    } else if let Ok(error) = Error::try_from(value) {
+        Err(error)
+    } else {
+        Err(Error::UnknownErrno(value))
+    }
+}
+
+/// Error values returned by NNG functions.
+/// The special errno flags NNG_ESYSERR/NNG_ETRANERR are represented by Error::SysErr() and Error::TranErr()
+#[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(i32)]
+pub enum NngErrno {
+    EINTR = runng_sys::NNG_EINTR as i32,
+    ENOMEM = runng_sys::NNG_ENOMEM as i32,
+    EINVAL = runng_sys::NNG_EINVAL as i32,
+    EBUSY = runng_sys::NNG_EBUSY as i32,
+    ETIMEDOUT = runng_sys::NNG_ETIMEDOUT as i32,
+    ECONNREFUSED = runng_sys::NNG_ECONNREFUSED as i32,
+    ECLOSED = runng_sys::NNG_ECLOSED as i32,
+    EAGAIN = runng_sys::NNG_EAGAIN as i32,
+    ENOTSUP = runng_sys::NNG_ENOTSUP as i32,
+    EADDRINUSE = runng_sys::NNG_EADDRINUSE as i32,
+    ESTATE = runng_sys::NNG_ESTATE as i32,
+    ENOENT = runng_sys::NNG_ENOENT as i32,
+    EPROTO = runng_sys::NNG_EPROTO as i32,
+    EUNREACHABLE = runng_sys::NNG_EUNREACHABLE as i32,
+    EADDRINVAL = runng_sys::NNG_EADDRINVAL as i32,
+    EPERM = runng_sys::NNG_EPERM as i32,
+    EMSGSIZE = runng_sys::NNG_EMSGSIZE as i32,
+    ECONNABORTED = runng_sys::NNG_ECONNABORTED as i32,
+    ECONNRESET = runng_sys::NNG_ECONNRESET as i32,
+    ECANCELED = runng_sys::NNG_ECANCELED as i32,
+    ENOFILES = runng_sys::NNG_ENOFILES as i32,
+    ENOSPC = runng_sys::NNG_ENOSPC as i32,
+    EEXIST = runng_sys::NNG_EEXIST as i32,
+    EREADONLY = runng_sys::NNG_EREADONLY as i32,
+    EWRITEONLY = runng_sys::NNG_EWRITEONLY as i32,
+    ECRYPTO = runng_sys::NNG_ECRYPTO as i32,
+    EPEERAUTH = runng_sys::NNG_EPEERAUTH as i32,
+    ENOARG = runng_sys::NNG_ENOARG as i32,
+    EAMBIGUOUS = runng_sys::NNG_EAMBIGUOUS as i32,
+    EBADTYPE = runng_sys::NNG_EBADTYPE as i32,
+    EINTERNAL = runng_sys::NNG_EINTERNAL as i32,
+    // ESYSERR(int),
+    // ETRANERR(int),
+}
+
+impl NngErrno {
+    // TODO: replace this with std::num::TryFromIntError once stabilized:
+    // https://doc.rust-lang.org/std/convert/trait.TryFrom.html
+    fn try_from(value: i32) -> result::Result<Self, TryFromIntError> {
+        match value {
+            value if value == NngErrno::EINTR as i32 => Ok(NngErrno::EINTR),
+            value if value == NngErrno::ENOMEM as i32 => Ok(NngErrno::ENOMEM),
+            value if value == NngErrno::EINVAL as i32 => Ok(NngErrno::EINVAL),
+            value if value == NngErrno::EBUSY as i32 => Ok(NngErrno::EBUSY),
+            value if value == NngErrno::ETIMEDOUT as i32 => Ok(NngErrno::ETIMEDOUT),
+            value if value == NngErrno::ECONNREFUSED as i32 => Ok(NngErrno::ECONNREFUSED),
+            value if value == NngErrno::ECLOSED as i32 => Ok(NngErrno::ECLOSED),
+            value if value == NngErrno::EAGAIN as i32 => Ok(NngErrno::EAGAIN),
+            value if value == NngErrno::ENOTSUP as i32 => Ok(NngErrno::ENOTSUP),
+            value if value == NngErrno::EADDRINUSE as i32 => Ok(NngErrno::EADDRINUSE),
+            value if value == NngErrno::ESTATE as i32 => Ok(NngErrno::ESTATE),
+            value if value == NngErrno::ENOENT as i32 => Ok(NngErrno::ENOENT),
+            value if value == NngErrno::EPROTO as i32 => Ok(NngErrno::EPROTO),
+            value if value == NngErrno::EUNREACHABLE as i32 => Ok(NngErrno::EUNREACHABLE),
+            value if value == NngErrno::EADDRINVAL as i32 => Ok(NngErrno::EADDRINVAL),
+            value if value == NngErrno::EPERM as i32 => Ok(NngErrno::EPERM),
+            value if value == NngErrno::EMSGSIZE as i32 => Ok(NngErrno::EMSGSIZE),
+            value if value == NngErrno::ECONNABORTED as i32 => Ok(NngErrno::ECONNABORTED),
+            value if value == NngErrno::ECONNRESET as i32 => Ok(NngErrno::ECONNRESET),
+            value if value == NngErrno::ECANCELED as i32 => Ok(NngErrno::ECANCELED),
+            value if value == NngErrno::ENOFILES as i32 => Ok(NngErrno::ENOFILES),
+            value if value == NngErrno::ENOSPC as i32 => Ok(NngErrno::ENOSPC),
+            value if value == NngErrno::EEXIST as i32 => Ok(NngErrno::EEXIST),
+            value if value == NngErrno::EREADONLY as i32 => Ok(NngErrno::EREADONLY),
+            value if value == NngErrno::EWRITEONLY as i32 => Ok(NngErrno::EWRITEONLY),
+            value if value == NngErrno::ECRYPTO as i32 => Ok(NngErrno::ECRYPTO),
+            value if value == NngErrno::EPEERAUTH as i32 => Ok(NngErrno::EPEERAUTH),
+            value if value == NngErrno::ENOARG as i32 => Ok(NngErrno::ENOARG),
+            value if value == NngErrno::EAMBIGUOUS as i32 => Ok(NngErrno::EAMBIGUOUS),
+            value if value == NngErrno::EBADTYPE as i32 => Ok(NngErrno::EBADTYPE),
+            value if value == NngErrno::EINTERNAL as i32 => Ok(NngErrno::EINTERNAL),
+            _ => Err(TryFromIntError),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
 pub enum Error {
-    Errno(nng_errno_enum),
+    Errno(NngErrno),
+    /// NNG_ESYSERR
+    SysErr(i32),
+    /// NNG_ETRANERR
+    TranErr(i32),
     UnknownErrno(i32),
-    IoError(io::Error),
     NulError(std::ffi::NulError),
     Unit,
     Canceled(oneshot::Canceled),
 }
 
 impl Error {
-    /// Converts values returned by NNG methods into `Result<>`
-    pub fn from_i32(value: i32) -> Result<()> {
-        if value == 0 {
-            Ok(())
-        } else if let Ok(error) = Error::try_from(value) {
-            Err(error)
-        } else {
-            Err(Error::UnknownErrno(value))
-        }
-    }
     // TODO: replace this with std::num::TryFromIntError once stabilized:
     // https://doc.rust-lang.org/std/convert/trait.TryFrom.html
     fn try_from(value: i32) -> result::Result<Self, TryFromIntError> {
+        const ESYSERR: i32 = runng_sys::NNG_ESYSERR as i32;
+        const ETRANERR: i32 = runng_sys::NNG_ETRANERR as i32;
         if value == 0 {
             Err(TryFromIntError)
-        } else if let Ok(error) = nng_errno_enum::try_from(value) {
+        } else if let Ok(error) = NngErrno::try_from(value) {
             Ok(Error::Errno(error))
+        } else if value & ESYSERR != 0 {
+            Ok(Error::SysErr(value ^ ESYSERR))
+        } else if value & ETRANERR != 0 {
+            Ok(Error::SysErr(value ^ ETRANERR))
         } else {
             Ok(Error::UnknownErrno(value))
         }
     }
     /// If `value` is zero returns `Ok(result())`.  Otherwise converts `value` to an `Error` and returns that.
     pub fn zero_map<T, F: FnOnce() -> T>(value: i32, result: F) -> Result<T> {
-        Error::from_i32(value).map(|_| result())
+        nng_int_to_result(value).map(|_| result())
     }
 }
 
@@ -51,18 +143,13 @@ impl fmt::Display for Error {
         use Error::*;
         match self {
             Errno(ref err) => write!(f, "{:?}", err),
+            SysErr(ref err) => write!(f, "ESYSERR({})", err),
+            TranErr(ref err) => write!(f, "ETRANERR({})", err),
             UnknownErrno(ref err) => err.fmt(f),
-            IoError(ref err) => err.fmt(f),
             NulError(ref err) => err.fmt(f),
             Unit => write!(f, "()"),
             Canceled(ref err) => err.fmt(f),
         }
-    }
-}
-
-impl From<io::Error> for Error {
-    fn from(err: io::Error) -> Error {
-        Error::IoError(err)
     }
 }
 

--- a/runng/src/transport/mod.rs
+++ b/runng/src/transport/mod.rs
@@ -3,29 +3,29 @@
 use crate::*;
 
 pub fn nng_inproc_register() -> Result<()> {
-    unsafe { Error::from_i32(runng_sys::nng_inproc_register()) }
+    unsafe { nng_int_to_result(runng_sys::nng_inproc_register()) }
 }
 
 pub fn nng_ipc_register() -> Result<()> {
-    unsafe { Error::from_i32(runng_sys::nng_ipc_register()) }
+    unsafe { nng_int_to_result(runng_sys::nng_ipc_register()) }
 }
 
 pub fn nng_tcp_register() -> Result<()> {
-    unsafe { Error::from_i32(runng_sys::nng_tcp_register()) }
+    unsafe { nng_int_to_result(runng_sys::nng_tcp_register()) }
 }
 
 pub fn nng_tls_register() -> Result<()> {
-    unsafe { Error::from_i32(runng_sys::nng_tls_register()) }
+    unsafe { nng_int_to_result(runng_sys::nng_tls_register()) }
 }
 
 pub fn nng_wss_register() -> Result<()> {
-    unsafe { Error::from_i32(runng_sys::nng_wss_register()) }
+    unsafe { nng_int_to_result(runng_sys::nng_wss_register()) }
 }
 
 pub fn nng_ws_register() -> Result<()> {
-    unsafe { Error::from_i32(runng_sys::nng_ws_register()) }
+    unsafe { nng_int_to_result(runng_sys::nng_ws_register()) }
 }
 
 pub fn nng_zt_register() -> Result<()> {
-    unsafe { Error::from_i32(runng_sys::nng_zt_register()) }
+    unsafe { nng_int_to_result(runng_sys::nng_zt_register()) }
 }

--- a/runng_derive/src/lib.rs
+++ b/runng_derive/src/lib.rs
@@ -136,7 +136,7 @@ fn gen_get_impl(name: &syn::Ident, prefix: &str, member: &syn::Ident) -> TokenSt
                 unsafe {
                     let mut value: *mut ::std::os::raw::c_char = std::ptr::null_mut();
                     let res = #getopt_string (self.#member, option.as_cptr(), &mut value);
-                    Error::from_i32(res)?;
+                    nng_int_to_result(res)?;
                     Ok(NngString::new(value))
                 }
             }
@@ -163,33 +163,33 @@ fn gen_set_impl(name: &syn::Ident, prefix: &str, member: &syn::Ident) -> TokenSt
         impl SetOpts for #name {
             fn setopt_bool(&mut self, option: NngOption, value: bool) -> Result<()> {
                 unsafe {
-                    Error::from_i32(#setopt_bool(self.#member, option.as_cptr(), value))
+                    nng_int_to_result(#setopt_bool(self.#member, option.as_cptr(), value))
                 }
             }
             fn setopt_int(&mut self, option: NngOption, value: i32) -> Result<()> {
                 unsafe {
-                    Error::from_i32(#setopt_int(self.#member, option.as_cptr(), value))
+                    nng_int_to_result(#setopt_int(self.#member, option.as_cptr(), value))
                 }
             }
             fn setopt_ms(&mut self, option: NngOption, value: i32) -> Result<()> {
                 unsafe {
-                    Error::from_i32(#setopt_ms(self.#member, option.as_cptr(), value))
+                    nng_int_to_result(#setopt_ms(self.#member, option.as_cptr(), value))
                 }
             }
             fn setopt_size(&mut self, option: NngOption, value: usize) -> Result<()> {
                 unsafe {
-                    Error::from_i32(#setopt_size(self.#member, option.as_cptr(), value))
+                    nng_int_to_result(#setopt_size(self.#member, option.as_cptr(), value))
                 }
             }
             fn setopt_uint64(&mut self, option: NngOption, value: u64) -> Result<()> {
                 unsafe {
-                    Error::from_i32(#setopt_uint64(self.#member, option.as_cptr(), value))
+                    nng_int_to_result(#setopt_uint64(self.#member, option.as_cptr(), value))
                 }
             }
             fn setopt_string(&mut self, option: NngOption, value: &str) -> Result<()> {
                 unsafe {
                     let (_, value) = to_cstr(value)?;
-                    Error::from_i32(#setopt_string(self.#member, option.as_cptr(), value))
+                    nng_int_to_result(#setopt_string(self.#member, option.as_cptr(), value))
                 }
             }
         }
@@ -202,7 +202,7 @@ fn _derive_nng_msg() -> TokenStream {
     let add_methods = methods.map(|(member, method, utype)| {
         quote! {
             pub fn #member(&mut self, data: #utype) -> Result<()> {
-                unsafe { Error::from_i32(#method(self.msg(), data)) }
+                unsafe { nng_int_to_result(#method(self.msg(), data)) }
             }
         }
     });


### PR DESCRIPTION
- ESYSERR and ETRANERR are flags and handled by `enum Error`
- Replace from_i32 that turned int into Result (where 0 was Ok) with `nng_int_to_result`