### PR TITLE
Bump rust to 1.33, stop running bindgen and remove clang depdendency …

### DIFF
--- a/dockerfiles/rust-arm32/Dockerfile
+++ b/dockerfiles/rust-arm32/Dockerfile
@@ -1,4 +1,4 @@
-# jeikabu/debian-rust:arm32v7-stretch-1.32.0
+# jeikabu/debian-rust:arm32v7-stretch-1.33.0
 # Rust on ARM32
 
 FROM multiarch/debian-debootstrap:armhf-stretch
@@ -6,11 +6,10 @@ FROM multiarch/debian-debootstrap:armhf-stretch
 RUN apt-get update && apt-get install -y \
     build-essential \
     ca-certificates \
-    clang \
     cmake \
     curl
 
-ARG RUST_VER=1.32.0
+ARG RUST_VER=1.33.0
 
 # Make sure rustup and cargo are in PATH
 ENV PATH "~/.cargo/bin:$PATH"

--- a/dockerfiles/rust-arm64/Dockerfile
+++ b/dockerfiles/rust-arm64/Dockerfile
@@ -1,4 +1,4 @@
-# jeikabu/debian-rust:arm64v8-stretch-1.32.0
+# jeikabu/debian-rust:arm64v8-stretch-1.33.0
 # Rust on ARM64
 
 FROM multiarch/debian-debootstrap:arm64-stretch
@@ -6,11 +6,10 @@ FROM multiarch/debian-debootstrap:arm64-stretch
 RUN apt-get update && apt-get install -y \
     build-essential \
     ca-certificates \
-    clang \
     cmake \
     curl
 
-ARG RUST_VER=1.32.0
+ARG RUST_VER=1.33.0
 
 # Make sure rustup and cargo are in PATH
 ENV PATH "~/.cargo/bin:$PATH"

--- a/runng/Cargo.toml
+++ b/runng/Cargo.toml
@@ -28,7 +28,17 @@ futures = "0.1"
 log = "0.4"
 rand = "0.6"
 runng_derive = { version = "0.1", path = "../runng_derive" }
-runng-sys = { version = "1.1.1-rc", path = "../runng_sys", package = "nng-sys", features = ["build-bindgen"] }
+runng-sys = { version = "1.1.1-rc", path = "../runng_sys", package = "nng-sys" }
+
+# To enable bindgen only when building for PC, I'd like to have:
+#[target.'cfg(target_arch = "x86_64")'.dependencies]
+#runng-sys = { version = "1.1.1-rc", path = "../runng_sys", package = "nng-sys", features = ["build-bindgen"] }
+#[target.'cfg(target_arch = "aarch64")'.dependencies]
+#runng-sys = { version = "1.1.1-rc", path = "../runng_sys", package = "nng-sys" }
+#
+# But that doesn't work, `features` are set regardless of target arch.  
+# Instead, could ignore the `build-bindgen` feature but that complicates everything:
+#cfg!(any(target_arch = "arm", target_arch = "aarch64"))
 
 [dev-dependencies]
 env_logger = "0.6"

--- a/scripts/qemu_arm32.sh
+++ b/scripts/qemu_arm32.sh
@@ -2,5 +2,5 @@
 
 if [[ "$TRAVIS_OS_NAME" == "linux" ]] || [[ "$OSTYPE" == "linux-gnu" ]]; then
     docker run --rm --privileged multiarch/qemu-user-static:register --reset
-    docker run -t -v $(pwd):/usr/src jeikabu/debian-rust:arm32v7-stretch-1.32.0 /bin/bash -c "cd /usr/src; cargo test"
+    docker run -t -v $(pwd):/usr/src jeikabu/debian-rust:arm32v7-stretch-1.33.0 /bin/bash -c "cd /usr/src; cargo test"
 fi

--- a/scripts/qemu_arm64.sh
+++ b/scripts/qemu_arm64.sh
@@ -2,5 +2,5 @@
 
 if [[ "$TRAVIS_OS_NAME" == "linux" ]] || [[ "$OSTYPE" == "linux-gnu" ]]; then
     docker run --rm --privileged multiarch/qemu-user-static:register --reset
-    docker run -t -v $(pwd):/usr/src jeikabu/debian-rust:arm64v8-stretch-1.32.0 /bin/bash -c "cd /usr/src; cargo test"
+    docker run -t -v $(pwd):/usr/src jeikabu/debian-rust:arm64v8-stretch-1.33.0 /bin/bash -c "cd /usr/src; cargo test"
 fi


### PR DESCRIPTION
…on arm32/64

- Even when using `cfg()` in Cargo.toml to attempt to conditionally
enable runng-sys feature `build-bindgen`, if it's enabled anywhere it's
enabled everywhere
- Tests fails on arm32 because hard-coded size is for 64-bit pointers