### PR TITLE
Test for complex broker and misbehaving puller

### DIFF
--- a/runng/Cargo.toml
+++ b/runng/Cargo.toml
@@ -42,4 +42,5 @@ runng-sys = { version = "1.1.1-rc", path = "../runng_sys", package = "nng-sys" }
 
 [dev-dependencies]
 env_logger = "0.6"
+failure = "0.1"
 futures-timer = "0.1"

--- a/runng/src/asyncio/mod.rs
+++ b/runng/src/asyncio/mod.rs
@@ -98,7 +98,9 @@ struct WorkQueue {
 impl WorkQueue {
     fn push_back(&mut self, message: Result<NngMsg>) {
         if let Some(sender) = self.waiting.pop_front() {
-            sender.send(message).unwrap();
+            sender
+                .send(message)
+                .unwrap_or_else(|_msg| debug!("Dropping message"));
         } else {
             self.ready.push_back(message);
         }

--- a/runng/src/result.rs
+++ b/runng/src/result.rs
@@ -61,6 +61,7 @@ pub enum NngErrno {
 impl NngErrno {
     // TODO: replace this with std::num::TryFromIntError once stabilized:
     // https://doc.rust-lang.org/std/convert/trait.TryFrom.html
+    #[allow(clippy::cyclomatic_complexity)]
     fn try_from(value: i32) -> result::Result<Self, TryFromIntError> {
         match value {
             value if value == NngErrno::EINTR as i32 => Ok(NngErrno::EINTR),

--- a/runng/src/socket.rs
+++ b/runng/src/socket.rs
@@ -297,7 +297,7 @@ pub trait SendMsg: Socket {
 pub trait RecvMsg: Socket {
     /// Receive data.  See [nng_recv](https://nanomsg.github.io/nng/man/v1.1.0/nng_recv.3).
     fn recv(&self) -> Result<()> {
-        Ok(())
+        unimplemented!()
     }
     fn recv_zerocopy(&self) -> Result<memory::Alloc> {
         self.recv_zerocopy_flags(Default::default())
@@ -357,7 +357,7 @@ struct InnerSocket {
 impl Drop for InnerSocket {
     fn drop(&mut self) {
         unsafe {
-            debug!("Socket close: {:?}", self.socket);
+            trace!("Socket close: {:?}", self.socket);
             let res = nng_int_to_result(nng_close(self.socket));
             match res {
                 Ok(()) => {}

--- a/runng/tests/common/mod.rs
+++ b/runng/tests/common/mod.rs
@@ -1,5 +1,8 @@
 use env_logger::{Builder, Env};
-use futures::{future, Future};
+use futures::{
+    future,
+    future::{Either, Future},
+};
 use rand::Rng;
 use runng::msg::NngMsg;
 use std::{
@@ -35,8 +38,33 @@ pub fn sleep_fast() {
     thread::sleep(time::Duration::from_millis(10));
 }
 
+pub fn sleep_brief() {
+    thread::sleep(time::Duration::from_millis(25));
+}
+
+pub fn sleep_test() {
+    thread::sleep(time::Duration::from_secs(1));
+}
+
 pub fn rand_msg() -> runng::Result<NngMsg> {
     let mut msg = NngMsg::with_size(128)?;
     rand::thread_rng().fill(msg.as_mut_slice());
     Ok(msg)
+}
+
+pub enum TimeoutResult<F: Future> {
+    Ok(F::Item),
+    Timeout(F),
+}
+
+pub fn timeout<F: Future>(
+    future: F,
+    duration: std::time::Duration,
+) -> impl Future<Item = TimeoutResult<F>, Error = ()> {
+    let timeout = futures_timer::Delay::new(duration);
+    future.select2(timeout).then(|res| match res {
+        Ok(Either::A((item, _timeout_future))) => future::ok(TimeoutResult::Ok(item)),
+        Ok(Either::B((_timeout_error, future))) => future::ok(TimeoutResult::Timeout(future)),
+        _ => future::err(()),
+    })
 }

--- a/runng/tests/tests.rs
+++ b/runng/tests/tests.rs
@@ -3,6 +3,8 @@ mod common;
 #[cfg(test)]
 mod tests {
 
+    mod broker_tests;
+    mod future_tests;
     mod msg_tests;
     mod options_tests;
     mod pair_tests;
@@ -39,18 +41,18 @@ mod tests {
                     );
                     req_dialer.start()?;
                     requester.sendmsg(msg::NngMsg::create()?)?;
-                    let _request = replier.recv()?;
+                    let _request = replier.recvmsg()?;
                     // Drop the dialer
                 }
                 // requester still works
                 requester.sendmsg(msg::NngMsg::create()?)?;
-                let _request = replier.recv()?;
+                let _request = replier.recvmsg()?;
                 // Drop the listener
             }
             // Replier still works
             let requester = factory.requester_open()?.dial(&url)?;
             requester.sendmsg(msg::NngMsg::create()?)?;
-            let _request = replier.recv()?;
+            let _request = replier.recvmsg()?;
         }
 
         Ok(())

--- a/runng/tests/tests/broker_tests.rs
+++ b/runng/tests/tests/broker_tests.rs
@@ -1,0 +1,106 @@
+use crate::common::*;
+use failure::Error;
+use futures::future::{Future, IntoFuture};
+use log::debug;
+use runng::{
+    asyncio::*,
+    msg::NngMsg,
+    options::{NngOption, SetOpts},
+    protocol::*,
+    socket::*,
+    NngErrno,
+};
+use std::{
+    sync::{
+        atomic::{AtomicBool, AtomicUsize, Ordering},
+        Arc,
+    },
+    thread,
+    time::Duration,
+};
+
+#[test]
+fn simple() -> Result<(), Error> {
+    init_logging();
+    let in_url = get_url();
+    let out_url = get_url();
+
+    let mut broker_in = Pull0::open()?;
+    broker_in
+        .socket_mut()
+        .setopt_ms(NngOption::RECVTIMEO, 100)?;
+    let broker_in = broker_in.listen(&in_url)?;
+    let broker_out = Push0::open()?.listen(&out_url)?;
+
+    let done = Arc::new(AtomicBool::default());
+    let forwarded_count = Arc::new(AtomicUsize::new(0));
+    let send_count = Arc::new(AtomicUsize::new(0));
+    let recv_count = Arc::new(AtomicUsize::new(0));
+
+    let broker_args = (done.clone(), forwarded_count.clone());
+    let broker_thread = thread::spawn(move || -> Result<(), Error> {
+        let (done, forwarded_count) = broker_args;
+        let mut broker_in = broker_in.create_async()?;
+        let mut broker_out = broker_out.create_async()?;
+        while !done.load(Ordering::Relaxed) {
+            match broker_in.receive().wait() {
+                Ok(Ok(mut msg)) => {
+                    forwarded_count.fetch_add(1, Ordering::Relaxed);
+                    broker_out.send(msg).wait().unwrap();
+                }
+                Ok(Err(runng::Error::Errno(NngErrno::ETIMEDOUT))) => break,
+                Ok(Err(err)) => panic!(err),
+                _ => panic!(),
+            }
+        }
+
+        Ok(())
+    });
+
+    let server_args = (done.clone(), send_count.clone());
+    let server_thread = thread::spawn(move || -> Result<(), Error> {
+        let (done, send_count) = server_args;
+        let mut ctx = Push0::open()?.dial(&in_url)?.create_async()?;
+        while !done.load(Ordering::Relaxed) {
+            let msg = NngMsg::create()?;
+            ctx.send(msg).wait()??;
+            send_count.fetch_add(1, Ordering::Relaxed);
+            sleep_brief();
+        }
+        Ok(())
+    });
+
+    let client_args = (done.clone(), recv_count.clone());
+    let client_thread = thread::spawn(move || -> Result<(), Error> {
+        let (done, recv_count) = client_args;
+        let mut ctx = Pull0::open()?.dial(&out_url)?;
+        ctx.socket_mut().setopt_ms(NngOption::RECVTIMEO, 100)?;
+        let mut ctx = ctx.create_async()?;
+        while !done.load(Ordering::Relaxed) {
+            match ctx.receive().wait() {
+                Ok(Ok(mut msg)) => {
+                    recv_count.fetch_add(1, Ordering::Relaxed);
+                }
+                Ok(Err(runng::Error::Errno(NngErrno::ETIMEDOUT))) => break,
+                Ok(Err(err)) => panic!(err),
+                _ => panic!(),
+            }
+        }
+        Ok(())
+    });
+
+    sleep_test();
+    done.store(true, Ordering::Relaxed);
+    server_thread.join().unwrap()?;
+    client_thread.join().unwrap()?;
+    broker_thread.join().unwrap()?;
+
+    let send_count = send_count.load(Ordering::Relaxed);
+    let forwarded_count = forwarded_count.load(Ordering::Relaxed);
+    let recv_count = recv_count.load(Ordering::Relaxed);
+    assert!(send_count > 1);
+    assert!(recv_count > 1);
+    assert!(send_count >= forwarded_count && forwarded_count >= recv_count);
+
+    Ok(())
+}

--- a/runng/tests/tests/future_tests.rs
+++ b/runng/tests/tests/future_tests.rs
@@ -1,0 +1,95 @@
+use crate::common::*;
+use failure::Error;
+use futures::future::{Future, IntoFuture};
+use log::debug;
+use rand::RngCore;
+use runng::{asyncio::*, factory::latest::ProtocolFactory, msg::NngMsg, protocol::*, socket::*};
+use std::{
+    sync::{
+        atomic::{AtomicBool, AtomicUsize, Ordering},
+        Arc,
+    },
+    thread,
+    time::Duration,
+};
+
+#[test]
+fn pushpull_timeout() -> runng::Result<()> {
+    let url = get_url();
+    let factory = ProtocolFactory::default();
+
+    let pusher = factory.pusher_open()?.listen(&url)?;
+
+    let puller_ready = Arc::new(AtomicBool::default());
+    let done = Arc::new(AtomicBool::default());
+    let push_vars = (done.clone(), puller_ready.clone());
+
+    // Pusher
+    let push_thread = thread::spawn(move || -> runng::Result<()> {
+        let (done, puller_ready) = push_vars;
+        let mut push_ctx = pusher.create_async()?;
+
+        // Wait for puller (or end of test)
+        while !puller_ready.load(Ordering::Relaxed) && !done.load(Ordering::Relaxed) {
+            sleep_brief();
+        }
+
+        // Send messages
+        let mut count = 1;
+        while !done.load(Ordering::Relaxed) {
+            let mut msg = NngMsg::create()?;
+            msg.append_u32(count)?;
+            push_ctx.send(msg).wait().unwrap()?;
+            count += 1;
+            sleep_brief();
+        }
+        Ok(())
+    });
+
+    // Puller
+    let puller = factory.puller_open()?.dial(&url)?;
+    let recv_count = Arc::new(AtomicUsize::new(0));
+    let lost_count = Arc::new(AtomicUsize::new(0));
+    let pull_vars = (done.clone(), recv_count.clone(), lost_count.clone());
+    let pull_thread = thread::spawn(move || -> runng::Result<()> {
+        let (done, recv_count, lost_count) = pull_vars;
+        let mut read_ctx = puller.create_async()?;
+        let mut recv_msg_id = 0;
+        puller_ready.store(true, Ordering::Relaxed);
+        while !done.load(Ordering::Relaxed) {
+            let recv_future = read_ctx.receive().into_future();
+            let duration = Duration::from_millis(100);
+            timeout(recv_future, duration)
+                .then(|res| match res {
+                    Ok(TimeoutResult::Ok(msg)) => {
+                        let id = msg.unwrap().trim_u32().unwrap();
+                        let expect_id = recv_msg_id + 1;
+                        if id != expect_id {
+                            debug!("Lost a message!  Expected {}, got {}", expect_id, id);
+                            lost_count.fetch_add((id - expect_id) as usize, Ordering::Relaxed);
+                        }
+                        recv_msg_id = id;
+                        recv_count.fetch_add(1, Ordering::Relaxed);
+                        Ok(())
+                    }
+                    _ => {
+                        debug!("Error");
+                        Err(())
+                    }
+                })
+                .wait();
+        }
+        Ok(())
+    });
+
+    sleep_test();
+    done.store(true, Ordering::Relaxed);
+
+    push_thread.join().unwrap()?;
+    pull_thread.join().unwrap()?;
+
+    assert!(recv_count.load(Ordering::Relaxed) > 1);
+    assert_eq!(0, lost_count.load(Ordering::Relaxed));
+
+    Ok(())
+}

--- a/runng/tests/tests/pushpull_tests.rs
+++ b/runng/tests/tests/pushpull_tests.rs
@@ -1,31 +1,69 @@
-use crate::common::{create_stop_message, get_url, not_stop_message};
-use futures::{future::Future, Stream};
-use runng::{asyncio::*, factory::latest::ProtocolFactory, msg::NngMsg, socket::*};
+use crate::common::*;
+use futures::{
+    future::{Future, IntoFuture},
+    Stream,
+};
+use log::debug;
+use rand::RngCore;
+use runng::{
+    asyncio::*,
+    factory::latest::ProtocolFactory,
+    msg::NngMsg,
+    options::{NngOption, SetOpts},
+    protocol,
+    socket::*,
+    NngErrno,
+};
 use std::{
     sync::{
-        atomic::{AtomicUsize, Ordering},
+        atomic::{AtomicBool, AtomicUsize, Ordering},
         Arc,
     },
     thread,
+    time::Duration,
 };
 
-#[test]
-fn pushpull() -> runng::Result<()> {
-    let url = get_url();
-    let factory = ProtocolFactory::default();
+fn create_pusher(url: &str) -> runng::Result<protocol::Push0> {
+    let mut sock = protocol::Push0::open()?;
+    sock.socket_mut().setopt_ms(NngOption::RECVTIMEO, 100)?;
+    sock.socket_mut().setopt_ms(NngOption::SENDTIMEO, 100)?;
+    sock.listen(&url)
+}
 
-    let pusher = factory.pusher_open()?.listen(&url)?;
-    let puller = factory.puller_open()?.dial(&url)?;
-    let count = 4;
+fn create_puller(url: &str) -> runng::Result<protocol::Pull0> {
+    let mut sock = protocol::Pull0::open()?;
+    sock.socket_mut().setopt_ms(NngOption::RECVTIMEO, 100)?;
+    sock.socket_mut().setopt_ms(NngOption::SENDTIMEO, 100)?;
+    sock.dial(&url)
+}
+
+#[test]
+fn pull_stream() -> runng::Result<()> {
+    let url = get_url();
+    let pusher = create_pusher(&url)?;
+    let puller = create_puller(&url)?;
+
+    let puller_ready = Arc::new(AtomicBool::default());
+    let done = Arc::new(AtomicBool::default());
 
     // Pusher
+    let push_vars = (puller_ready.clone(), done.clone());
     let push_thread = thread::spawn(move || -> runng::Result<()> {
         let mut push_ctx = pusher.create_async()?;
-        // Send messages
-        for i in 0..count {
+        let (puller_ready, done) = push_vars;
+
+        // Wait for puller (or end of test)
+        while !puller_ready.load(Ordering::Relaxed) && !done.load(Ordering::Relaxed) {
+            sleep_brief();
+        }
+
+        let mut count = 1;
+        while !done.load(Ordering::Relaxed) {
             let mut msg = NngMsg::create()?;
-            msg.append_u32(i)?;
+            msg.append_u32(count)?;
+            count += 1;
             push_ctx.send(msg).wait().unwrap()?;
+            sleep_brief();
         }
         // Send a stop message
         push_ctx.send(create_stop_message()).wait().unwrap()?;
@@ -34,9 +72,11 @@ fn pushpull() -> runng::Result<()> {
 
     // Puller
     let recv_count = Arc::new(AtomicUsize::new(0));
-    let thread_count = recv_count.clone();
+    let pull_vars = (puller_ready.clone(), recv_count.clone());
     let pull_thread = thread::spawn(move || -> runng::Result<()> {
         let mut pull_ctx = puller.create_async_stream(1)?;
+        let (puller_ready, recv_count) = pull_vars;
+        puller_ready.store(true, Ordering::Relaxed);
         pull_ctx
             .receive()
             .unwrap()
@@ -44,19 +84,18 @@ fn pushpull() -> runng::Result<()> {
             .take_while(not_stop_message)
             // Increment count of received messages
             .for_each(|_| {
-                thread_count.fetch_add(1, Ordering::Relaxed);
+                recv_count.fetch_add(1, Ordering::Relaxed);
                 Ok(())
             })
-            .wait()
-            .unwrap();
+            .wait()?;
         Ok(())
     });
 
+    sleep_test();
+    done.store(true, Ordering::Relaxed);
     push_thread.join().unwrap()?;
     pull_thread.join().unwrap()?;
-
-    // Received number of messages we sent
-    assert_eq!(recv_count.load(Ordering::Relaxed), count as usize);
+    assert!(recv_count.load(Ordering::Relaxed) > 1);
 
     Ok(())
 }
@@ -66,18 +105,30 @@ fn read() -> runng::Result<()> {
     let url = get_url();
     let factory = ProtocolFactory::default();
 
-    let pusher = factory.pusher_open()?.listen(&url)?;
-    let puller = factory.puller_open()?.dial(&url)?;
-    let count = 4;
+    let pusher = create_pusher(&url)?;
+    let puller = create_puller(&url)?;
+    let puller_ready = Arc::new(AtomicBool::default());
+    let done = Arc::new(AtomicBool::default());
 
     // Pusher
+    let push_vars = (puller_ready.clone(), done.clone());
     let push_thread = thread::spawn(move || -> runng::Result<()> {
+        let (puller_ready, done) = push_vars;
         let mut push_ctx = pusher.create_async()?;
+
+        // Wait for puller (or end of test)
+        while !puller_ready.load(Ordering::Relaxed) && !done.load(Ordering::Relaxed) {
+            sleep_brief();
+        }
+
         // Send messages
-        for i in 0..count {
+        let mut count = 1;
+        while !done.load(Ordering::Relaxed) {
             let mut msg = NngMsg::create()?;
-            msg.append_u32(i)?;
+            msg.append_u32(count)?;
+            count += 1;
             push_ctx.send(msg).wait().unwrap()?;
+            sleep_brief();
         }
         // Send a stop message
         push_ctx.send(create_stop_message()).wait().unwrap()?;
@@ -86,10 +137,12 @@ fn read() -> runng::Result<()> {
 
     // Puller
     let recv_count = Arc::new(AtomicUsize::new(0));
-    let thread_count = recv_count.clone();
+    let pull_vars = (puller_ready.clone(), done.clone(), recv_count.clone());
     let pull_thread = thread::spawn(move || -> runng::Result<()> {
+        let (puller_ready, done, thread_count) = pull_vars;
         let mut read_ctx = puller.create_async()?;
-        loop {
+        puller_ready.store(true, Ordering::Relaxed);
+        while !done.load(Ordering::Relaxed) {
             let msg = read_ctx.receive().wait()??;
             if msg.is_empty() {
                 break;
@@ -100,51 +153,102 @@ fn read() -> runng::Result<()> {
         Ok(())
     });
 
+    sleep_test();
+    done.store(true, Ordering::Relaxed);
+
     push_thread.join().unwrap()?;
     pull_thread.join().unwrap()?;
 
     // Received number of messages we sent
-    assert_eq!(recv_count.load(Ordering::Relaxed), count as usize);
+    assert!(recv_count.load(Ordering::Relaxed) > 1);
 
     Ok(())
 }
 
-// #[test]
-// fn crash() -> runng::Result<()> {
-//     let url = get_url();
-//     let factory = ProtocolFactory::default();
+#[test]
+fn bad_puller() -> runng::Result<()> {
+    let url = get_url();
+    let factory = ProtocolFactory::default();
 
-//     let pusher = factory.pusher_open()?.listen(&url)?;
-//     let puller = factory.puller_open()?.dial(&url)?;
+    let pusher = create_pusher(&url)?;
 
-//     // Pusher
-//     let push_thread = thread::spawn(move || -> runng::Result<()> {
-//         let mut push_ctx = pusher.create_async()?;
-//         // Send messages
-//         loop {
-//             let msg = NngMsg::create()?;
-//             push_ctx.send(msg).wait().unwrap()?;
-//         }
-//         Ok(())
-//     });
+    let puller_ready = Arc::new(AtomicBool::default());
+    let done = Arc::new(AtomicBool::default());
+    let push_vars = (done.clone(), puller_ready.clone());
 
-//     // Puller
-//     let recv_count = Arc::new(AtomicUsize::new(0));
-//     let thread_count = recv_count.clone();
-//     let pull_thread = thread::spawn(move || -> runng::Result<()> {
-//         puller.create_async()?
-//             .receive().unwrap()
-//             .for_each(|msg| {
-//                 debug!("Pulled: {:?}", msg);
-//                 Ok(())
-//             }
-//             )
-//             .wait().unwrap();
-//         Ok(())
-//     });
+    // Pusher
+    let push_thread = thread::spawn(move || -> runng::Result<()> {
+        let (done, puller_ready) = push_vars;
+        let mut push_ctx = pusher.create_async()?;
 
-//     push_thread.join().unwrap();
-//     pull_thread.join().unwrap();
+        // Wait for puller (or end of test)
+        while !puller_ready.load(Ordering::Relaxed) && !done.load(Ordering::Relaxed) {
+            sleep_brief();
+        }
 
-//     Ok(())
-// }
+        // Send messages
+        let mut count = 1;
+        while !done.load(Ordering::Relaxed) {
+            let mut msg = NngMsg::create()?;
+            msg.append_u32(count)?;
+            push_ctx.send(msg).wait().unwrap()?;
+            count += 1;
+            sleep_brief();
+        }
+        Ok(())
+    });
+
+    // Puller
+    let puller = create_puller(&url)?;
+    let recv_count = Arc::new(AtomicUsize::new(0));
+    let lost_count = Arc::new(AtomicUsize::new(0));
+    let pull_vars = (done.clone(), recv_count.clone(), lost_count.clone());
+    let pull_thread = thread::spawn(move || -> runng::Result<()> {
+        let (done, recv_count, lost_count) = pull_vars;
+        let mut ctx = puller.create_async()?;
+        let mut recv_msg_id = 0;
+        puller_ready.store(true, Ordering::Relaxed);
+        while !done.load(Ordering::Relaxed) {
+            match ctx.receive().wait() {
+                Ok(Ok(mut msg)) => {
+                    let id = msg.trim_u32()?;
+                    let expect_id = recv_msg_id + 1;
+                    if id != expect_id {
+                        debug!("Lost a message!  Expected {}, got {}", expect_id, id);
+                        lost_count.fetch_add((id - expect_id) as usize, Ordering::Relaxed);
+                    }
+                    recv_msg_id = id;
+                    recv_count.fetch_add(1, Ordering::Relaxed);
+                }
+                Ok(Err(runng::Error::Errno(NngErrno::ETIMEDOUT))) => break,
+                Ok(Err(err)) => panic!(err),
+                _ => break,
+            }
+        }
+        Ok(())
+    });
+
+    let pull_vars = (done.clone());
+    let _bad_thread = thread::spawn(move || -> runng::Result<()> {
+        let (done) = pull_vars;
+        while !done.load(Ordering::Relaxed) {
+            let puller = factory.puller_open()?.dial(&url)?;
+            let mut read_ctx = puller.create_async()?;
+            let recv_future = read_ctx.receive();
+            let rand_sleep = ((rand::thread_rng().next_u64() & 0x7) + 1) * 2;
+            thread::sleep(Duration::from_millis(rand_sleep));
+        }
+        Ok(())
+    });
+
+    sleep_test();
+    done.store(true, Ordering::Relaxed);
+
+    push_thread.join().unwrap()?;
+    pull_thread.join().unwrap()?;
+
+    assert!(recv_count.load(Ordering::Relaxed) > 1);
+    assert_eq!(0, lost_count.load(Ordering::Relaxed));
+
+    Ok(())
+}

--- a/runng/tests/tests/reqrep_tests.rs
+++ b/runng/tests/tests/reqrep_tests.rs
@@ -15,46 +15,6 @@ use std::{
 };
 
 #[test]
-fn example_basic() -> runng::Result<()> {
-    let url = get_url();
-
-    let factory = ProtocolFactory::default();
-    let rep = factory.replier_open()?.listen(&url)?;
-    let req = factory.requester_open()?.dial(&url)?;
-    req.sendmsg(NngMsg::create()?)?;
-    rep.recv()?;
-
-    Ok(())
-}
-
-#[test]
-fn example_async() -> runng::Result<()> {
-    let url = get_url();
-
-    let factory = ProtocolFactory::default();
-    let mut rep_ctx = factory
-        .replier_open()?
-        .listen(&url)?
-        .create_async_stream(1)?;
-
-    let mut req_ctx = factory.requester_open()?.dial(&url)?.create_async()?;
-    let req_future = req_ctx.send(NngMsg::create()?);
-    rep_ctx
-        .receive()
-        .unwrap()
-        .take(1)
-        .for_each(|_request| {
-            let msg = NngMsg::create().unwrap();
-            rep_ctx.reply(msg).wait().unwrap().unwrap();
-            Ok(())
-        })
-        .wait()?;
-    req_future.wait().unwrap()?;
-
-    Ok(())
-}
-
-#[test]
 fn zerocopy() -> runng::Result<()> {
     let url = get_url();
 
@@ -127,7 +87,7 @@ fn nonblock() -> runng::Result<()> {
         let request = receive_loop(&rep);
         req.recvmsg_flags(socket::Flags::NONBLOCK);
         send_loop(&rep, request);
-        let reply = receive_loop(&req);
+        let _reply = receive_loop(&req);
         //assert_eq!(data, reply);
     }
 


### PR DESCRIPTION
- Improve pair tests
- Switch future timeeouts for NNG socket timeouts
- Run tests for fixed amount of time rather than fixed number of messages
- Async stream receive only used in specific tests
- Apparently NngStatRoot doesn't need lifetime, only NngStatChild