### PR TITLE
v0.3.2 nng@v1.2.4

### DIFF
--- a/runng/Cargo.toml
+++ b/runng/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runng"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["Jake W <jeikabu@gmail.com>"]
 
 description = "High-level wrapper around nng (Nanomsg-Next-Generation) aka Nanomsg2"
@@ -17,6 +17,8 @@ codecov = { repository = "jeikabu/runng", branch = "master", service = "github" 
 
 [features]
 default = ["pipes", "stats"]
+# Unstable features that will change without warning
+unstable = []
 # NngPipe/nng_pipe
 pipes = []
 stats = []
@@ -28,7 +30,7 @@ futures_util = { version = "0.3.0-alpha", package = "futures-util-preview" }
 log = "0.4"
 rand = "0.6"
 runng_derive = { version = "0.2", path = "../runng_derive" }
-runng-sys = { version = "1.2.3-rc", path = "../runng_sys", package = "nng-sys" }
+runng-sys = { version = "1.2.4-rc" }
 
 # To enable bindgen only when building for PC, I'd like to have:
 #[target.'cfg(target_arch = "x86_64")'.dependencies]

--- a/runng/src/dialer.rs
+++ b/runng/src/dialer.rs
@@ -30,6 +30,17 @@ impl NngDialer {
     pub fn start(&self) -> Result<()> {
         unsafe { nng_int_to_result(nng_dialer_start(self.dialer, 0)) }
     }
+
+    #[cfg(feature = "unstable")]
+    pub fn getopt_sockaddr(&self, option: NngOption) -> Result<nng_sockaddr> {
+        unsafe {
+            let mut sockaddr = nng_sockaddr::default();
+            Error::zero_map(
+                nng_dialer_getopt_sockaddr(self.dialer, option.as_cptr(), &mut sockaddr),
+                || sockaddr,
+            )
+        }
+    }
 }
 
 impl NngWrapper for NngDialer {

--- a/runng/src/listener.rs
+++ b/runng/src/listener.rs
@@ -29,6 +29,17 @@ impl NngListener {
         // be set before the dialer is started.
         unsafe { nng_int_to_result(nng_listener_start(self.listener, 0)) }
     }
+
+    #[cfg(feature = "unstable")]
+    pub fn getopt_sockaddr(&self, option: NngOption) -> Result<nng_sockaddr> {
+        unsafe {
+            let mut sockaddr = nng_sockaddr::default();
+            Error::zero_map(
+                nng_listener_getopt_sockaddr(self.listener, option.as_cptr(), &mut sockaddr),
+                || sockaddr,
+            )
+        }
+    }
 }
 
 impl NngWrapper for NngListener {

--- a/runng/src/pipe.rs
+++ b/runng/src/pipe.rs
@@ -101,6 +101,17 @@ impl NngPipe {
     pub unsafe fn close(self) -> Result<()> {
         nng_int_to_result(nng_pipe_close(self.pipe))
     }
+
+    #[cfg(feature = "unstable")]
+    pub fn getopt_sockaddr(&self, option: NngOption) -> Result<nng_sockaddr> {
+        unsafe {
+            let mut sockaddr = nng_sockaddr::default();
+            Error::zero_map(
+                nng_pipe_getopt_sockaddr(self.pipe, option.as_cptr(), &mut sockaddr),
+                || sockaddr,
+            )
+        }
+    }
 }
 
 impl NngWrapper for NngPipe {

--- a/runng/src/result.rs
+++ b/runng/src/result.rs
@@ -142,6 +142,7 @@ pub enum Error {
     NulError(std::ffi::NulError),
     Unit,
     Canceled(oneshot::Canceled),
+    TryFromError(i32),
 }
 
 impl Error {
@@ -184,6 +185,7 @@ impl fmt::Display for Error {
             NulError(ref err) => err.fmt(f),
             Unit => write!(f, "()"),
             Canceled(ref err) => err.fmt(f),
+            TryFromError(value) => write!(f, "EnumFromIntError({})", value),
         }
     }
 }
@@ -203,5 +205,11 @@ impl From<()> for Error {
 impl From<oneshot::Canceled> for Error {
     fn from(err: oneshot::Canceled) -> Error {
         Error::Canceled(err)
+    }
+}
+
+impl From<EnumFromIntError> for Error {
+    fn from(err: EnumFromIntError) -> Error {
+        Error::TryFromError(err.0)
     }
 }

--- a/runng/src/stats.rs
+++ b/runng/src/stats.rs
@@ -26,12 +26,6 @@ use runng::{
 
 #[test]
 fn stats_example() -> Result<()> {
-    // https://github.com/nanomsg/nng/issues/841
-    let url = "inproc://test";
-    let factory = ProtocolFactory::default();
-    let _pusher = factory.pusher_open()?.listen(&url)?;
-    let _puller = factory.puller_open()?.dial(&url)?;
-
     let stats = NngStatRoot::new()?;
     let child = stats.child().unwrap();
     for stat in child.iter() {
@@ -59,7 +53,7 @@ pub trait NngStat {
     }
 }
 
-/* Root of tree of statistics snapshot.
+/** Root of tree of statistics snapshot.
 ## Examples
 ```rust
 # use runng::stats::*;

--- a/runng/tests/tests/bus_tests.rs
+++ b/runng/tests/tests/bus_tests.rs
@@ -5,7 +5,9 @@ use runng::{
     options::{NngOption, SetOpts},
     socket::*,
 };
+use runng_sys::nng_sockaddr_family;
 use std::{
+    convert::TryFrom,
     sync::{
         atomic::{AtomicBool, AtomicUsize, Ordering},
         Arc,
@@ -81,6 +83,21 @@ fn create_peer_sync(
 
         Ok(())
     })
+}
+
+#[cfg(feature = "unstable")]
+#[test]
+fn get_loc_addr() -> runng::Result<()> {
+    let mut socket = protocol::Bus0::open()?;
+    let listener = socket.listener_create("tcp://localhost:0")?;
+    let sockaddr = listener.getopt_sockaddr(NngOption::LOCADDR)?;
+    let family = unsafe { nng_sockaddr_family::try_from(sockaddr.s_family as i32) }?;
+    assert!(
+        family == nng_sockaddr_family::NNG_AF_INET || family == nng_sockaddr_family::NNG_AF_INET6,
+        "{:?}",
+        family
+    );
+    Ok(())
 }
 
 #[test]

--- a/runng/tests/tests/stats_tests.rs
+++ b/runng/tests/tests/stats_tests.rs
@@ -6,8 +6,6 @@ use runng::{factory::compat::ProtocolFactory, socket::*, stats::*};
 
 fn init_stats() -> runng::Result<(protocol::pair0::Pair0, protocol::pair0::Pair0)> {
     init_logging();
-    // FIXME: can remove this in NNG 1.1.2 or 1.2
-    // https://github.com/nanomsg/nng/issues/841
     let url = get_url();
     let factory = ProtocolFactory::default();
     let mut p0 = factory.pair_open()?;


### PR DESCRIPTION
- `unstable` feature for in-development code
- getopt_sockaddr() implementation for dialer/listener/pipe behind unstable feature flag
- Can create `Error` from `EnumFromIntError`