### PR TITLE
Skip unwrapping reply if the receiver has been dropped

### DIFF
--- a/runng/src/asyncio/reply.rs
+++ b/runng/src/asyncio/reply.rs
@@ -164,7 +164,11 @@ unsafe extern "C" fn reply_callback(arg: AioArgPtr) {
             // not yet ready for receive() to be called.
             ctx.state = ReplyState::Idle;
             ctx.receive();
-            sender.send(res).unwrap();
+            // Unwrapping here may cause a panic. This might fail because the requester timed out
+            // and decided to drop. That will cascade all the way back to this callback which
+            // shouldn't care — if the replier needs to send something and nobody is listening, it
+            // should probably just ignore any problems.
+            let _ = sender.send(res);
         }
     }
 }


### PR DESCRIPTION
The comment in the diff explains the gist of it, but I've noticed that this sometimes occurs on certain platforms (specifically aarch64-unknown-linux-gnu, but it also occurs randomly on x86_64-unknown-linux-gnu). 

Either way, there's no reason to unwrap in the offending callback. I don't know if there's other places where this occurs, but I'd love if it was possible to get a new version out with this fix. 

Thanks again for the crate!